### PR TITLE
Add CLion to 'Other tools'

### DIFF
--- a/dev/compilation-database.rst
+++ b/dev/compilation-database.rst
@@ -156,6 +156,8 @@ Other tools
 
 * `Sourcetrail <https://www.sourcetrail.com>`_
 
+* `CLion <https://www.jetbrains.com/clion/>`_
+
 .. seealso::
 
    Some of the tools listed here:


### PR DESCRIPTION
Starting 2018.2 EAP, CLion IDE can open projects from compilation databases. Feature announcement: https://blog.jetbrains.com/clion/2018/05/clion-2018-2-eap-open-project-from-compilation-database/