### PR TITLE
compilation-database: add a portable sed invocation

### DIFF
--- a/dev/compilation-database.rst
+++ b/dev/compilation-database.rst
@@ -202,9 +202,13 @@ Usage::
   clang++ -MJ b.o.json -Wall -std=c++11 -o b.o -c b.cpp
 
 To merge the compilation database entries into a valid compilation database,
-it is possible to use ``sed``::
+it is possible to use (GNU) ``sed``::
 
   sed -e '1s/^/[\n/' -e '$s/,$/\n]/' *.o.json > compile_commands.json
+
+Or, using any ``sed`` under Bash, Zsh or ksh::
+
+  sed -e '1s/^/[\'$'\n''/' -e '$s/,$/\'$'\n'']/' *.o.json > compile_commands.json
 
 This ``sed`` invocation does the following:
 


### PR DESCRIPTION
The given `sed` invocation to merge compilation database entries
generated by clang's `-MJ` flag is not POSIX compliant, as such
it does not work on macOS or other BSDs.

Add an alternative using ANSI-C Quoting to quote the newline, which
should work in Bash, Zsh and ksh.

Reference: https://stackoverflow.com/a/24299845