### PR TITLE
compilation-database: add `kompiledb` to 'Other tools'

### DIFF
--- a/dev/compilation-database.rst
+++ b/dev/compilation-database.rst
@@ -159,6 +159,9 @@ Other tools
 
 * `CLion <https://www.jetbrains.com/clion/>`_
 
+* `kompiledb <https://github.com/saveourtool/kompiledb>`_, the Kotlin bindings
+  to compilation database format.
+
 .. seealso::
 
    Some of the tools listed here:


### PR DESCRIPTION
[`kompiledb`](https://github.com/saveourtool/kompiledb) is a Kotlin library which can read and write `compile_commands.json`, and has a command-line parser for GCC and compatibles, such as Clang.